### PR TITLE
LIBASPACE-53. Provision with the aspace-env.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,18 @@ UMD Libraries' ArchivesSpace Vagrant
   vagrant package --output solr.box
 ```
 
-* An ArchivesSpace Solr core at `/apps/git/archivesspace-core`:
+* An [archivesspace-core] Solr core at `/apps/git/archivesspace-core`:
   
   ```bash
   cd /apps/git
   git clone git@bitbucket.org:umd-lib/archivesspace-core.git
+  ```
+  
+* An [aspace-env] runtime environment at `/apps/git/aspace-env`:
+
+  ```bash
+  cd /apps/git
+  git clone git@bitbucket.org:umd-lib/aspace-env.git
   ```
 
 ## Quick Start
@@ -69,3 +76,5 @@ See the [LICENSE](LICENSE.md) file for license rights and limitations (Apache 2.
 
 [jdk]: http://www.oracle.com/technetwork/java/javase/downloads/index-jsp-138363.html
 [solr-vagrant-base]: https://github.com/umd-lib/solr-vagrant-base
+[archivesspace-core]: https://bitbucket.org/umd-lib/archivesspace-core
+[aspace-env]: https://bitbucket.org/umd-lib/aspace-env

--- a/files/env
+++ b/files/env
@@ -1,0 +1,6 @@
+# vi:ft=sh
+# Server-specific variables
+export SERVER_NAME=aspacelocal
+export ASPACE_DB_URL="jdbc:mysql://localhost:3306/archivesspace?user=as&password=as&useUnicode=true&characterEncoding=UTF-8"
+export ASPACE_EXTERNAL_SOLR=true
+export ASPACE_SOLR_URL="http://192.168.40.101:8984/solr/archivesspace"

--- a/manifests/aspace.pp
+++ b/manifests/aspace.pp
@@ -21,3 +21,6 @@ package { "vim-enhanced":
 package { "unzip":
   ensure => present,
 }
+package { 'git':
+  ensure => present,
+}

--- a/scripts/aspace.sh
+++ b/scripts/aspace.sh
@@ -11,10 +11,7 @@ if [ ! -e "$ASPACE_PKG" ]; then
     curl -Lso "$ASPACE_PKG" "$ASPACE_PKG_URL"
 fi
 
-cd /apps
-unzip "$ASPACE_PKG"
-mv archivesspace "archivesspace-${ASPACE_VERSION}"
+# unzip without overwriting existing files
+unzip -n -d /apps/aspace "$ASPACE_PKG"
 
-mkdir -p /apps/aspace/aspace/{data,logs}
-chown -R "$SERVICE_USER_GROUP" /apps/aspace \
-    /apps/"archivesspace-${ASPACE_VERSION}"/{config,archivesspace.sh}
+chown -R "$SERVICE_USER_GROUP" /apps/aspace/archivesspace

--- a/scripts/database.sh
+++ b/scripts/database.sh
@@ -1,10 +1,11 @@
 #/bin/bash
 
-ASPACE_VERSION=1.5.2
 MYSQL_JDBC_VERSION=5.1.38
 
 # set up MySQL database
-cd /apps/"archivesspace-${ASPACE_VERSION}"
+cd /apps/aspace/archivesspace
 curl -Lso lib/mysql-connector-java-${MYSQL_JDBC_VERSION}.jar \
     https://maven.lib.umd.edu/nexus/service/local/repositories/central/content/mysql/mysql-connector-java/${MYSQL_JDBC_VERSION}/mysql-connector-java-${MYSQL_JDBC_VERSION}.jar
+
+source /apps/aspace/config/env
 scripts/setup-database.sh

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+SERVICE_USER_GROUP=vagrant:vagrant
+
+ENV_SRC_DIR=/apps/git/aspace-env
+ENV_TARGET_DIR=/apps/aspace
+
+git clone "file://$ENV_SRC_DIR/.git" "$ENV_TARGET_DIR"
+chown -R "$SERVICE_USER_GROUP" "$ENV_TARGET_DIR"

--- a/scripts/git.sh
+++ b/scripts/git.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+NAME=$1
+EMAIL=$2
+
+git config --global user.name "$NAME"
+git config --global user.email "$EMAIL"
+git config --global color.ui true


### PR DESCRIPTION
* Install git
* Provisions with an env file with server-specific info for the Vagrant
* Adjust the assumed layout of the /apps directory in the aspace.sh and database.sh scripts

https://issues.umd.edu/browse/LIBASPACE-53