### PR TITLE
LIBASPACE-31. Close port 8080.

### DIFF
--- a/manifests/aspace.pp
+++ b/manifests/aspace.pp
@@ -29,7 +29,7 @@ package { 'mysql-server':
 }
 
 firewall { '100 allow http and https access':
-  dport  => [80, 443, 8080],
+  dport  => [80, 443],
   proto  => tcp,
   action => accept,
 }


### PR DESCRIPTION
Not needed since CAS authentication is working against https://aspacelocal now.

https://issues.umd.edu/browse/LIBASPACE-31