### PR TITLE
LIBASPACE-78 Bump version to 2.0.1

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,7 +35,7 @@ Vagrant.configure("2") do |config|
 
     aspace.vm.provider "virtualbox" do |vb|
       # Customize the amount of memory on the VM
-      vb.memory = "1024"
+      vb.memory = "1280"
     end
 
     aspace.vm.provision 'shell', inline: 'puppet module install puppetlabs-firewall'

--- a/scripts/aspace.sh
+++ b/scripts/aspace.sh
@@ -3,7 +3,7 @@
 SERVICE_USER_GROUP=vagrant:vagrant
 
 # Aspace
-ASPACE_VERSION=1.5.2
+ASPACE_VERSION=2.0.1
 ASPACE_PKG=/apps/dist/archivesspace-v${ASPACE_VERSION}.zip
 # look for a cached tarball
 if [ ! -e "$ASPACE_PKG" ]; then


### PR DESCRIPTION
This updates aspace version to 2.0.1.

https://issues.umd.edu/browse/LIBASPACE-78