### PR TITLE
LIBASPACE-147. Pinned puppetlabs-firewall version to v1.10.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -42,7 +42,9 @@ Vagrant.configure("2") do |config|
       vb.memory = "1280"
     end
 
-    aspace.vm.provision 'shell', inline: 'puppet module install puppetlabs-firewall'
+    aspace.vm.provision "shell", inline: <<-SHELL
+      puppet module install puppetlabs-firewall --version 1.10.0
+    SHELL
 
     # system packages
     aspace.vm.provision 'puppet', manifest_file: 'aspace.pp'


### PR DESCRIPTION
Pinned "puppetlabs-firewall" resource to v1.10.0, as v1.11.0
contains changes that cause errors and break the Vagrant
build process.

https://issues.umd.edu/browse/LIBASPACE-147