### PR TITLE
LIBASPACE-122 Bump Aspace version to 2.2.2

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,7 +41,7 @@ Vagrant.configure("2") do |config|
       # Customize the amount of memory on the VM
       vb.memory = "1280"
     end
-    
+
     aspace.vm.provision 'shell', inline: 'yum --disablerepo=puppetlabs-pc1 update -y'
     aspace.vm.provision "shell", inline: <<-SHELL
       puppet module install puppetlabs-firewall --version 1.10.0
@@ -53,11 +53,11 @@ Vagrant.configure("2") do |config|
     # configure Git
     aspace.vm.provision 'shell', path: 'scripts/git.sh', args: [git_username, git_email], privileged: false
     # install runtime env
-    if copy_dont_git 
+    if copy_dont_git
       aspace.vm.provision "shell", path: "scripts/env_no_git.sh"
     else
       aspace.vm.provision "shell", path: "scripts/env.sh"
-    end 
+    end
     # Oracle JDK
     aspace.vm.provision 'shell', path: 'scripts/jdk.sh'
 
@@ -77,13 +77,16 @@ Vagrant.configure("2") do |config|
     aspace.vm.provision 'shell', path: 'scripts/mysql.sh'
     # install JDBC driver and setup database
     aspace.vm.provision 'shell', path: 'scripts/database.sh', privileged: false
-    
-    # install plugins 
+
+    # install plugins
     aspace.vm.provision 'shell', inline: '/apps/aspace/scripts/plugins.sh', privileged: false
-    
-    # tweak the archivesspace.sh script 
+
+    # local fixup for CAS OAuth
+    aspace.vm.provision 'file', source: 'files/aspace-oauth.frontend.plugin_init.rb', destination: '/apps/aspace/archivesspace/plugins/aspace-oauth/frontend/plugin_init.rb'
+
+    # tweak the archivesspace.sh script
     aspace.vm.provision 'shell', inline: '/apps/aspace/scripts/append_log.sh', privileged: false
-    # add log rotate configuration 
+    # add log rotate configuration
     aspace.vm.provision 'shell' do |s|
       s.inline = 'cp /apps/git/aspace-env/config/etc/logrotate.d/aspace /etc/logrotate.d/aspace'
       s.privileged = true

--- a/files/aspace-oauth.frontend.plugin_init.rb
+++ b/files/aspace-oauth.frontend.plugin_init.rb
@@ -1,0 +1,48 @@
+oauth_definitions = AppConfig[:authentication_sources].find_all { |as|
+  as[:model] == 'ASOauth'
+}
+raise "OmniAuth plugin enabled but no definitions provided =(" unless oauth_definitions.any?
+
+# GOOGLE STRATEGY FOR TESTING [DO NOT USE IN PROD UNLESS YOU MEAN TO]
+def google_oauth_enabled?
+  ENV.has_key?('GOOGLE_CLIENT_ID') and ENV.has_key?('GOOGLE_CLIENT_SECRET')
+end
+
+# also used for ui [refactor]
+AppConfig[:oauth_definitions] = oauth_definitions.delete_if { |oauth_definition|
+  oauth_definition[:provider] == 'google_oauth2' and not google_oauth_enabled?
+}
+
+ArchivesSpace::Application.extend_aspace_routes(File.join(File.dirname(__FILE__), "routes.rb"))
+
+require 'omniauth'
+OmniAuth.config.full_host = 'https://aspacelocal'
+require 'omniauth-google-oauth2' if google_oauth_enabled?
+
+Rails.application.config.middleware.use OmniAuth::Builder do
+  oauth_definitions.each do |oauth_definition|
+    if oauth_definition[:provider] == 'google_oauth2'
+      provider :google_oauth2,
+        ENV['GOOGLE_CLIENT_ID'],
+        ENV['GOOGLE_CLIENT_SECRET'],
+        access_type: 'online',
+        prompt: ''
+    else
+      config = oauth_definition[:config]
+      if oauth_definition.has_key? :metadata_parser_url
+        idp_metadata_parser = OneLogin::RubySaml::IdpMetadataParser.new
+        idp_metadata        = idp_metadata_parser.parse_remote_to_hash(oauth_definition[:metadata_parser_url])
+
+        config = idp_metadata.merge(config)
+      end
+      if config.has_key? :security
+        # replace strings with constants for *_method
+        [:digest_method, :signature_method].each do |m|
+          config[:security][m] = config[:security][m].constantize if config[:security].has_key? m
+        end
+      end
+      provider oauth_definition[:provider], config
+      $stdout.puts "\n\n\nREGISTERED OAUTH PROVIDER WITH CONFIG: #{config}\n\n\n"
+    end
+  end
+end

--- a/scripts/aspace.sh
+++ b/scripts/aspace.sh
@@ -3,7 +3,7 @@
 SERVICE_USER_GROUP=vagrant:vagrant
 
 # Aspace
-ASPACE_VERSION=2.1.2
+ASPACE_VERSION=2.2.2
 ASPACE_PKG=/apps/dist/archivesspace-v${ASPACE_VERSION}.zip
 # look for a cached tarball
 if [ ! -e "$ASPACE_PKG" ]; then


### PR DESCRIPTION
This bumps the aspace version to 2.2.2. Be sure to add a copy of the
release to the dist directory.

https://issues.umd.edu/browse/LIBASPACE-122