### PR TITLE
LIBASPACE-202 update to AS 2.5.1

### DIFF
--- a/scripts/aspace.sh
+++ b/scripts/aspace.sh
@@ -3,7 +3,7 @@
 SERVICE_USER_GROUP=vagrant:vagrant
 
 # Aspace
-ASPACE_VERSION=2.2.2
+ASPACE_VERSION=2.5.1
 ASPACE_PKG=/apps/dist/archivesspace-v${ASPACE_VERSION}.zip
 # look for a cached tarball
 if [ ! -e "$ASPACE_PKG" ]; then


### PR DESCRIPTION
This updates the vagrant to version 2.5.1

https://issues.umd.edu/browse/LIBASPACE-202